### PR TITLE
Add missing import of dot

### DIFF
--- a/src/genericblas.jl
+++ b/src/genericblas.jl
@@ -1,4 +1,4 @@
-import LinearAlgebra: BLAS, BlasFloat, norm
+import LinearAlgebra: BLAS, BlasFloat, norm, dot
 
 genblas_dot(x::Vector{T}, y::Vector{T}) where {T<:BlasFloat} = BLAS.dot(x, y)
 genblas_dot(x, y) = dot(x,y)


### PR DESCRIPTION
Otherwise, I get
```julia
  UndefVarError: `dot` not defined
```
coming from
https://github.com/mcovalt/ConjugateGradients.jl/blob/12a23dd7d43177a15bb75508312386d43eed6108/src/genericblas.jl#L4
when using something else than `Float64`